### PR TITLE
actually hash submitted buildinfo

### DIFF
--- a/bidb/api/utils.py
+++ b/bidb/api/utils.py
@@ -35,7 +35,7 @@ def parse_submission(request):
         except (KeyError, IndexError):
             raise InvalidBuildinfo("Could not determine GPG uid")
 
-    sha1 = hashlib.sha1().hexdigest()
+    sha1 = hashlib.sha1(raw_text_gpg_stripped.encode('utf-8')).hexdigest()
     try:
         submission = Buildinfo.objects.get(sha1=sha1).submissions.create(
             uid=uid,


### PR DESCRIPTION
Actually hash the .buildinfo content (without signature) instead of always
using the hash for "" (da39a3ee5e6b4b0d3255bfef95601890afd80709).

(untested)