### PR TITLE
Buildinfo since endpoint

### DIFF
--- a/bidb/api/urls.py
+++ b/bidb/api/urls.py
@@ -5,6 +5,6 @@ from . import views
 urlpatterns = (
     url(r'^api/submit$', views.submit,
         name='submit'),
-    url(r'^api/buildinfo/since/(?P<date>[^/]+)$', views.buildinfo_since,
+    url(r'^api/buildinfo/since/(?P<date>\d+)$', views.buildinfo_since,
         name='buildinfo_since'),
 )

--- a/bidb/api/urls.py
+++ b/bidb/api/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = (
     url(r'^api/submit$', views.submit,
         name='submit'),
+    url(r'^api/buildinfo/since/(?P<date>[^/]+)$', views.buildinfo_since,
+        name='buildinfo_since'),
 )

--- a/bidb/api/views.py
+++ b/bidb/api/views.py
@@ -1,7 +1,11 @@
+import datetime
+
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
+
+from ..buildinfo.models import Buildinfo
 
 from .utils import parse_submission, InvalidSubmission
 
@@ -18,3 +22,27 @@ def submit(request):
         settings.SITE_URL,
         submission.buildinfo.get_absolute_url(),
     ), status=201 if created else 200)
+
+
+@require_http_methods(['GET'])
+def buildinfo_since(request, date):
+    time = datetime.datetime.fromtimestamp(int(date))
+    buildinfo = Buildinfo.objects.filter(
+            created__gt=time
+    ).select_related(
+        'source',
+        'architecture',
+    ).order_by()
+    return JsonResponse({'buildinfos': [{
+        'uri': '{}{}'.format(
+            settings.SITE_URL,
+            x.get_absolute_url(),
+        ),
+        'raw-uri': '{}{}'.format(
+            settings.SITE_URL,
+            x.get_absolute_raw_url(),
+        ),
+        'source': x.source.name,
+        'version': x.version,
+        'architecture': x.architecture.name,
+    } for x in buildinfo]})

--- a/bidb/api/views.py
+++ b/bidb/api/views.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
@@ -26,13 +27,13 @@ def submit(request):
 
 @require_http_methods(['GET'])
 def buildinfo_since(request, date):
-    time = datetime.datetime.fromtimestamp(int(date))
+    created = datetime.datetime.fromtimestamp(int(date) + 1)
     buildinfo = Buildinfo.objects.filter(
-            created__gt=time
+            created__gte=created
     ).select_related(
         'source',
         'architecture',
-    ).order_by()
+    ).order_by('created')
     return JsonResponse({'buildinfos': [{
         'uri': '{}{}'.format(
             settings.SITE_URL,
@@ -45,4 +46,5 @@ def buildinfo_since(request, date):
         'source': x.source.name,
         'version': x.version,
         'architecture': x.architecture.name,
+        'created':  time.mktime(x.created.timetuple()),
     } for x in buildinfo]})

--- a/bidb/fixtures/data.json
+++ b/bidb/fixtures/data.json
@@ -1,0 +1,25 @@
+[
+    {
+        "model": "packages.source",
+        "pk": 1,
+        "fields": {
+            "name": "Testy"
+        }
+    },
+    {
+        "model": "packages.architecture",
+        "pk": 1,
+        "fields": {
+            "name": "Testy Architecture"
+        }
+    },
+    {
+        "model": "buildinfo.buildinfo",
+        "pk": 1,
+        "fields": {
+            "architecture": 1,
+            "build_architecture": 1,
+            "source": 1
+        }
+    }
+]

--- a/bidb/fixtures/data.json
+++ b/bidb/fixtures/data.json
@@ -19,6 +19,8 @@
         "fields": {
             "architecture": 1,
             "build_architecture": 1,
+            "sha1": "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e",
+            "version": "1",
             "source": 1
         }
     }


### PR DESCRIPTION
Implements a endpoint returning a list of buildinfo files since a given
date given in Unix time.

Example: GET /api/buildinfo/since/0

Signed-off-by: Morten Linderud <morten@linderud.pw>